### PR TITLE
Upgrade xterm-addon-ligatures for WebGL support

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,9 +15,7 @@ Use fonts supporting ligatures such as [Fira Code][Fira Code],
 **Disclaimer**: Please note that this plugin requires hyper version 2.1.0
 or later.
 
-**Also note**: For those on hyper 3+, you must
-[disable WebGL rendering](#disabling-webgl-rendering) for this
-plugin to function.
+**Also note**: For those using WebGL, there are several known issues. To avoid these issues, [disable WebGL rendering](#disabling-webgl-rendering).
 
 ### Using the built-in hyper plugin manager
 ```bash
@@ -30,15 +28,14 @@ plugins array to include `hyper-font-ligatures`:
 ```js
 plugins: ['hyper-font-ligatures'],
 ```
+### WebGL Rendering Issues
+
+If you are running hyper with WebGL rendering enabled, you may run into some rendering glitches. See these issues for more information:
+
+- https://github.com/vercel/hyper/issues/5757
+- https://github.com/xtermjs/xterm.js/issues/3303
 
 ### Disabling WebGL Rendering
-
-if you are running hyper 3+, this plugin currently does not work with hyper 3
-unless you disable WebGL rendering.
-
-Note that WebGL rendering was a major performance improvement introduced
-in hyper 3, by disabling it you should expect the same level of performance
-seen with hyper 2.
 
 To disable WebGL rendering, set `webGLRenderer` to `false` in the `config`
 section of your

--- a/index.js
+++ b/index.js
@@ -1,10 +1,11 @@
-const ligatures = require('xterm-addon-ligatures');
+const { LigaturesAddon } = require('xterm-addon-ligatures');
 
 exports.decorateTerm = (Term, { React,  notify }) => {
   return class extends React.Component {
     constructor(props, context) {
       super(props, context);
       this.onDecorated = this.onDecorated.bind(this);
+      this.ligaturesAddon = new LigaturesAddon();
     }
 
     onDecorated(term) {
@@ -17,7 +18,7 @@ exports.decorateTerm = (Term, { React,  notify }) => {
       }
 
       if (term.term) {
-        ligatures.enableLigatures(term.term);
+        term.term.loadAddon(this.ligaturesAddon)
       }
     }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hyper-font-ligatures",
-  "version": "0.0.8",
+  "version": "0.0.9",
   "description": "Extension for Hyper.app to enable Font Ligatures",
   "main": "index.js",
   "repository": "https://github.com/tolbertam/hyper-font-ligatures",
@@ -10,7 +10,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "xterm-addon-ligatures": "0.1.0-beta-2"
+    "xterm-addon-ligatures": "0.5.1"
   },
   "keywords": [
     "hyper",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "xterm-addon-ligatures": "0.5.1"
+    "xterm-addon-ligatures": "0.6.0-beta.1"
   },
   "keywords": [
     "hyper",

--- a/yarn.lock
+++ b/yarn.lock
@@ -51,10 +51,10 @@ tiny-inflate@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/tiny-inflate/-/tiny-inflate-1.0.2.tgz#93d9decffc8805bd57eae4310f0b745e9b6fb3a7"
 
-xterm-addon-ligatures@0.5.1:
-  version "0.5.1"
-  resolved "https://registry.npmjs.org/xterm-addon-ligatures/-/xterm-addon-ligatures-0.5.1.tgz#40ff69c43b6406aaf130fdfe9a43ca4eac49f892"
-  integrity sha512-L70vyVAapDvBBti1bqFTUQOd6R6LH5qKzqZ76sERKkf75+u++sylqflCdwT8zmorK6zxcc3vq4+I4GDYawgYrQ==
+xterm-addon-ligatures@0.6.0-beta.1:
+  version "0.6.0-beta.1"
+  resolved "https://registry.npmjs.org/xterm-addon-ligatures/-/xterm-addon-ligatures-0.6.0-beta.1.tgz#4c91c045eb1dd2b7ec77330ec7cc68cd46194db6"
+  integrity sha512-rhn/bZfmQJcTDHfe7WwvqA8XGWyN9Kl+FCEy23J87C14OI9Ao0sEMZ2XeXHINVJleUKl3gCxxAAQcYRUb5JCQw==
   dependencies:
     font-finder "^1.1.0"
     font-ligatures "^1.4.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,31 +2,40 @@
 # yarn lockfile v1
 
 
-font-finder@^1.0.2, font-finder@^1.0.3:
+font-finder@^1.0.3:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/font-finder/-/font-finder-1.0.4.tgz#2ca944954dd8d0e1b5bdc4c596cc08607761d89b"
   dependencies:
     get-system-fonts "^2.0.0"
     promise-stream-reader "^1.0.1"
 
-font-ligatures@^1.3.1:
-  version "1.3.2"
-  resolved "https://registry.yarnpkg.com/font-ligatures/-/font-ligatures-1.3.2.tgz#227eb5fc38fef34b5373aa19b555320b82842a71"
+font-finder@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/font-finder/-/font-finder-1.1.0.tgz#2bff2b2762acba720239c8bec898a96daae90858"
+  integrity sha512-wpCL2uIbi6GurJbU7ZlQ3nGd61Ho+dSU6U83/xJT5UPFfN35EeCW/rOtS+5k+IuEZu2SYmHzDIPL9eA5tSYRAw==
+  dependencies:
+    get-system-fonts "^2.0.0"
+    promise-stream-reader "^1.0.1"
+
+font-ligatures@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.npmjs.org/font-ligatures/-/font-ligatures-1.4.0.tgz#6a7b370d96be1358dddfad67830e82fbfd59e6dc"
+  integrity sha512-n7DFnnEpJ0NrVoLqZIL4tMGVs+CnFwQc92m80LWyrbgAFO4x234+t2/H9o4eOYA1eh6ta9dZAEEsJAwsBdNezA==
   dependencies:
     font-finder "^1.0.3"
-    lru-cache "^4.1.3"
+    lru-cache "^6.0.0"
     opentype.js "^0.8.0"
 
 get-system-fonts@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/get-system-fonts/-/get-system-fonts-2.0.0.tgz#a43b9a33f05c0715a60176d2aad5ce6e98f0a3c6"
 
-lru-cache@^4.1.3:
-  version "4.1.3"
-  resolved "https://registry.yarnpkg.com/lru-cache/-/lru-cache-4.1.3.tgz#a1175cf3496dfc8436c156c334b4955992bce69c"
+lru-cache@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz#6d6fe6570ebd96aaf90fcad1dafa3b2566db3a94"
+  integrity sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
   dependencies:
-    pseudomap "^1.0.2"
-    yallist "^2.1.2"
+    yallist "^4.0.0"
 
 opentype.js@^0.8.0:
   version "0.8.0"
@@ -38,21 +47,19 @@ promise-stream-reader@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/promise-stream-reader/-/promise-stream-reader-1.0.1.tgz#4e793a79c9d49a73ccd947c6da9c127f12923649"
 
-pseudomap@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/pseudomap/-/pseudomap-1.0.2.tgz#f052a28da70e618917ef0a8ac34c1ae5a68286b3"
-
 tiny-inflate@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/tiny-inflate/-/tiny-inflate-1.0.2.tgz#93d9decffc8805bd57eae4310f0b745e9b6fb3a7"
 
-xterm-addon-ligatures@0.1.0-beta-2:
-  version "0.1.0-beta-2"
-  resolved "https://registry.yarnpkg.com/xterm-addon-ligatures/-/xterm-addon-ligatures-0.1.0-beta-2.tgz#def635fd0ca671fe61179629f8492b76c66dec6e"
+xterm-addon-ligatures@0.5.1:
+  version "0.5.1"
+  resolved "https://registry.npmjs.org/xterm-addon-ligatures/-/xterm-addon-ligatures-0.5.1.tgz#40ff69c43b6406aaf130fdfe9a43ca4eac49f892"
+  integrity sha512-L70vyVAapDvBBti1bqFTUQOd6R6LH5qKzqZ76sERKkf75+u++sylqflCdwT8zmorK6zxcc3vq4+I4GDYawgYrQ==
   dependencies:
-    font-finder "^1.0.2"
-    font-ligatures "^1.3.1"
+    font-finder "^1.1.0"
+    font-ligatures "^1.4.0"
 
-yallist@^2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
+yallist@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz#9bb92790d9c0effec63be73519e11a35019a3a72"
+  integrity sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==


### PR DESCRIPTION
See discussions here for context:
https://github.com/vercel/hyper/issues/3607#issuecomment-904832810
https://github.com/xtermjs/xterm.js/pull/3286
https://github.com/xtermjs/xterm.js/pull/2847
https://github.com/vercel/hyper/pull/5888

It should still be noted that there are some known issues with ligatures in WebGL (https://github.com/vercel/hyper/issues/5757 and https://github.com/xtermjs/xterm.js/issues/3303).  However, it's my opinion that it's still worth using ligatures in WebGL.  But users should know that enabling both may result in some rendering glitches.
